### PR TITLE
Fix typo in progressBar comment

### DIFF
--- a/_includes/scripts/progressBar.liquid
+++ b/_includes/scripts/progressBar.liquid
@@ -12,7 +12,7 @@
     /*
      * We set up the bar after all elements are done loading.
      * In some cases, if the images in the page are larger than the intended
-     * size they'll have on the page, they'll be resized via CSS to accomodate
+     * size they'll have on the page, they'll be resized via CSS to accommodate
      * the desired size. This mistake, however, breaks the computations as the
      * scroll size is computed as soon as the elements finish loading.
      * To account for this, a minimal delay was introduced before computing the


### PR DESCRIPTION
## Summary
- correct spelling of **accommodate** in progressBar script comment

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*