### PR TITLE
Fix FileExists plugin strip bug

### DIFF
--- a/_plugins/file-exists.rb
+++ b/_plugins/file-exists.rb
@@ -14,7 +14,8 @@ module Jekyll
       file_path = site_source + '/' + url
 
       # Check if file exists (returns true or false)
-      "#{File.exist?(file_path.strip!)}"
+      # use `strip` instead of `strip!` to avoid returning `nil`
+      "#{File.exist?(file_path.strip)}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix `FileExistsTag` bug by replacing `strip!` with `strip`

## Testing
- `ruby -c _plugins/file-exists.rb`